### PR TITLE
Add support for older Apple platforms

### DIFF
--- a/include/vt/scope-guard/detail/platform.h
+++ b/include/vt/scope-guard/detail/platform.h
@@ -10,8 +10,26 @@
 
 
 #if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411
+#if defined(__APPLE__)
+
+#include <Availability.h>
+
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200 \
+	|| defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000 \
+	|| defined(__TV_OS_VERSION_MIN_REQUIRED) && __TV_OS_VERSION_MIN_REQUIRED >= 100000 \
+	|| defined(__WATCH_OS_VERSION_MIN_REQUIRED) && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000
+#define VT_SCOPE_GUARD_SUPPORT_UNCAUGHT_EXCEPTIONS 1
+#endif
+
+#else
 
 #define VT_SCOPE_GUARD_SUPPORT_UNCAUGHT_EXCEPTIONS 1
+
+#endif
+#endif
+
+
+#if defined(VT_SCOPE_GUARD_SUPPORT_UNCAUGHT_EXCEPTIONS)
 
 namespace vt {
 namespace scopeGuard {
@@ -26,6 +44,7 @@ inline int uncaughtExceptions() {
 } // namespace vt
 
 #endif
+
 
 #include "gcc.h"
 #include "msvc.h"


### PR DESCRIPTION
There must be extra checks for Apple platforms because std::uncaught_exceptions
is defined with _LIBCPP_AVAILABILITY_UNCAUGHT_EXCEPTIONS which expands to
availability attributes.